### PR TITLE
Add BBP9981 third-party firmware links

### DIFF
--- a/includes/snippets/bb_keyboards_zitao.md
+++ b/includes/snippets/bb_keyboards_zitao.md
@@ -7,6 +7,7 @@
 ![Q10](https://img.shields.io/badge/Q10-null?logo=blackberry&logoColor=FFFFFF&color=000000)
 ![9900](https://img.shields.io/badge/9900-null?logo=blackberry&logoColor=FFFFFF&color=000000)
 ![P9983](https://img.shields.io/badge/P9983-null?logo=blackberry&logoColor=FFFFFF&color=000000)
+![P9981](https://img.shields.io/badge/P9981-null?logo=blackberry&logoColor=FFFFFF&color=000000)
 - Connectivity: ![Bluetooth](https://img.shields.io/badge/-Bluetooth-555555?logo=bluetooth&logoColor=FFFFFF&labelColor=0082FC) ![USB](https://img.shields.io/badge/-USB-555555?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAuMTg4IiBoZWlnaHQ9IjQ1MC40MjgiIHZpZXdCb3g9IjAgMCA1Mi45NjYgMTE5LjE3NiI+PHBhdGggZD0iTTI2LjQ4NiAwIDE4Ljg0IDEzLjIzOWg1LjQ1NHY2Ny42NjhMMTAuMzc0IDY3LjczYy0uODk5LTEuMTIxLTEuNTMtMi41ODgtMS41NjQtNC4wOTcgMC02LjEwNi0uMDAyLTkuNzMxLS4wMDUtMTEuMDY2IDIuNTc4LS45MDQgNC40MzgtMy4zMzQgNC40MzgtNi4yMjNhNi42MjIgNi42MjIgMCAwIDAtMTMuMjQzIDBjMCAyLjg4OSAxLjg2IDUuMzE5IDQuNDM0IDYuMjIzbC0uMDAxIDEwLjkzNmMwIDIuOTY0IDEuNjI2IDYuMDcgMy41MzIgOC4wNDYtLjA1Ny0uMDU0LS4xMTctLjExLjAwMS4wMDMuMDQ3LjA0MiAxNC43NjggMTMuOTggMTQuNzY4IDEzLjk4Ljg5NyAxLjExOCAxLjUyNCAyLjU4NSAxLjU2IDQuMDkzdjcuNjU1Yy01LjA1NyAxLjAxNC04Ljg2NyA1LjQ4LTguODY3IDEwLjgzNyAwIDYuMTA3IDQuOTUgMTEuMDU4IDExLjA1NiAxMS4wNTggNi4xMDcgMCAxMS4wNTgtNC45NSAxMS4wNTgtMTEuMDU4IDAtNS4zNTgtMy44MTMtOS44MjQtOC44NzQtMTAuODM4VjczLjA2NmMuMDM4LTEuNTA1LjY2NS0yLjk3IDEuNTY0LTQuMDg4IDAgMCAxNC43Mi0xMy45MzQgMTQuNzY3LTEzLjk3Ny4xMTgtLjExMS4wNTYtLjA1NiAwIDAgMS45MDctMS45NzcgMy41MzItNS4wODQgMy41MzItOC4wNDlsLS4wMDItMTAuNTM5aDQuNDM4VjIzLjE3MWgtMTMuMjR2MTMuMjQyaDQuNDMycy0uMDA1IDIuNzc2LS4wMDUgMTAuNjY4Yy0uMDM0IDEuNTEtLjY2NCAyLjk3OC0xLjU2MyA0LjFMMjguNjY3IDY0LjM1OHYtNTEuMTJoNS40NjN6IiBzdHlsZT0iZmlsbDojZmZmO2ZpbGwtb3BhY2l0eToxO3N0cm9rZS13aWR0aDouMjY0NTgzIi8+PC9zdmc+&logoColor=FFFFFF&labelColor=000000)
 - Battery: ![Nokia BL-5B](https://img.shields.io/badge/Nokia_BL--5B_(not_included)-~800_mAh-E65100?labelColor=555555)
 
@@ -34,6 +35,13 @@
 [![Github: zmk_config_Q10](https://img.shields.io/badge/repo-Q10-555555?logo=github&logoColor=FFFFFF&labelColor=181717)](https://github.com/ZitaoTech/zmk_config_Q10)
 - [![Github: zmk-config_9900](https://img.shields.io/badge/repo-9900-555555?logo=github&logoColor=FFFFFF&labelColor=181717)](https://github.com/ZitaoTech/zmk-config_9900)
 - [![Github: zmk-config_9983](https://img.shields.io/badge/repo-P9983-555555?logo=github&logoColor=FFFFFF&labelColor=181717)](https://github.com/ZitaoTech/zmk-config_9983)
+
+![3rd-party firmware: source available](https://img.shields.io/badge/3rd--party_firmware-source_available-1E88E5)
+
+- Community-maintained firmware is also available for the BBP9981 / 9981 Pro.
+- [![Github: BB9981 firmware](https://img.shields.io/badge/repo-BB9981_firmware-555555?logo=github&logoColor=FFFFFF&labelColor=181717)](https://github.com/moni11811/BB9981-KEYMAP)
+[![Github: BB9981 Studio app](https://img.shields.io/badge/repo-BB9981_Studio-555555?logo=github&logoColor=FFFFFF&labelColor=181717)](https://github.com/moni11811/zmk-studio-p9981)
+- [![Release: BB9981 firmware](https://img.shields.io/badge/release-BB9981_firmware-43A047)](https://github.com/moni11811/zmk-studio-p9981/releases/latest)
 
 <div markdown id="blueberry">
 ![BlueBerry Firmware: source available](https://img.shields.io/badge/BlueBerry_firmware-source_available-9E9D24)


### PR DESCRIPTION
## Summary
- add the BBP9981 / 9981 Pro to the Zitao keyboard model list
- add a clearly marked third-party firmware block for the BBP9981
- link the community firmware repo, Studio app repo, and latest release page

## Notes
- kept this explicitly separate from the official Zitao firmware links
- local mkdocs build was not run here because the docs toolchain is not installed in this environment